### PR TITLE
[xcore] Mark features as transient when not used in grammar

### DIFF
--- a/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/N4FieldDeclaration.java
+++ b/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/N4FieldDeclaration.java
@@ -39,7 +39,7 @@ public interface N4FieldDeclaration extends AnnotableN4MemberDeclaration, TypedE
 	 * @return the value of the '<em>Defined Field</em>' reference.
 	 * @see #setDefinedField(TField)
 	 * @see eu.numberfour.n4js.n4JS.N4JSPackage#getN4FieldDeclaration_DefinedField()
-	 * @model
+	 * @model transient="true"
 	 * @generated
 	 */
 	TField getDefinedField();

--- a/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/PropertyNameOwner.java
+++ b/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/PropertyNameOwner.java
@@ -39,7 +39,7 @@ public interface PropertyNameOwner extends NamedElement {
 	 * @see eu.numberfour.n4js.n4JS.PropertyNameKind
 	 * @see #setKind(PropertyNameKind)
 	 * @see eu.numberfour.n4js.n4JS.N4JSPackage#getPropertyNameOwner_Kind()
-	 * @model unique="false"
+	 * @model unique="false" transient="true"
 	 * @generated
 	 */
 	PropertyNameKind getKind();

--- a/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/PropertyNameValuePair.java
+++ b/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/PropertyNameValuePair.java
@@ -39,7 +39,7 @@ public interface PropertyNameValuePair extends AnnotablePropertyAssignment, Type
 	 * @return the value of the '<em>Defined Field</em>' reference.
 	 * @see #setDefinedField(TStructField)
 	 * @see eu.numberfour.n4js.n4JS.N4JSPackage#getPropertyNameValuePair_DefinedField()
-	 * @model
+	 * @model transient="true"
 	 * @generated
 	 */
 	TStructField getDefinedField();

--- a/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/SetterDeclaration.java
+++ b/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/SetterDeclaration.java
@@ -44,7 +44,7 @@ public interface SetterDeclaration extends FieldAccessor {
 	 * @return the value of the '<em>Defined Setter</em>' reference.
 	 * @see #setDefinedSetter(TSetter)
 	 * @see eu.numberfour.n4js.n4JS.N4JSPackage#getSetterDeclaration_DefinedSetter()
-	 * @model
+	 * @model transient="true"
 	 * @generated
 	 */
 	TSetter getDefinedSetter();

--- a/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/StrictModeRelevant.java
+++ b/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/StrictModeRelevant.java
@@ -37,7 +37,7 @@ public interface StrictModeRelevant extends EObject {
 	 * @return the value of the '<em>Strict Mode</em>' attribute.
 	 * @see #setStrictMode(boolean)
 	 * @see eu.numberfour.n4js.n4JS.N4JSPackage#getStrictModeRelevant_StrictMode()
-	 * @model unique="false" derived="true"
+	 * @model unique="false" transient="true" derived="true"
 	 * @generated
 	 */
 	boolean isStrictMode();

--- a/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/impl/N4JSPackageImpl.java
+++ b/plugins/eu.numberfour.n4js.model/emf-gen/eu/numberfour/n4js/n4JS/impl/N4JSPackageImpl.java
@@ -7169,7 +7169,7 @@ public class N4JSPackageImpl extends EPackageImpl implements N4JSPackage {
 		initEOperation(getIdentifierRef__IsValidSimpleAssignmentTarget(), theEcorePackage.getEBoolean(), "isValidSimpleAssignmentTarget", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEClass(strictModeRelevantEClass, StrictModeRelevant.class, "StrictModeRelevant", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(getStrictModeRelevant_StrictMode(), theEcorePackage.getEBoolean(), "strictMode", null, 0, 1, StrictModeRelevant.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getStrictModeRelevant_StrictMode(), theEcorePackage.getEBoolean(), "strictMode", null, 0, 1, StrictModeRelevant.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
 		initEClass(superLiteralEClass, SuperLiteral.class, "SuperLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
@@ -7200,7 +7200,7 @@ public class N4JSPackageImpl extends EPackageImpl implements N4JSPackage {
 		initEOperation(getPropertyAssignment__IsValidName(), theEcorePackage.getEBoolean(), "isValidName", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEClass(propertyNameOwnerEClass, PropertyNameOwner.class, "PropertyNameOwner", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(getPropertyNameOwner_Kind(), this.getPropertyNameKind(), "kind", null, 0, 1, PropertyNameOwner.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getPropertyNameOwner_Kind(), this.getPropertyNameKind(), "kind", null, 0, 1, PropertyNameOwner.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getPropertyNameOwner_Name(), theEcorePackage.getEString(), "name", null, 0, 1, PropertyNameOwner.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEOperation(getPropertyNameOwner__GetDefinedMember(), theTypesPackage.getTStructMember(), "getDefinedMember", 0, 1, !IS_UNIQUE, IS_ORDERED);
@@ -7217,7 +7217,7 @@ public class N4JSPackageImpl extends EPackageImpl implements N4JSPackage {
 		initEOperation(getPropertyAssignmentAnnotationList__GetDefinedMember(), theTypesPackage.getTStructMember(), "getDefinedMember", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEClass(propertyNameValuePairEClass, PropertyNameValuePair.class, "PropertyNameValuePair", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getPropertyNameValuePair_DefinedField(), theTypesPackage.getTStructField(), null, "definedField", null, 0, 1, PropertyNameValuePair.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getPropertyNameValuePair_DefinedField(), theTypesPackage.getTStructField(), null, "definedField", null, 0, 1, PropertyNameValuePair.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getPropertyNameValuePair_Expression(), this.getExpression(), null, "expression", null, 0, 1, PropertyNameValuePair.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEOperation(getPropertyNameValuePair__GetDefinedMember(), theTypesPackage.getTStructField(), "getDefinedMember", 0, 1, !IS_UNIQUE, IS_ORDERED);
@@ -7240,7 +7240,7 @@ public class N4JSPackageImpl extends EPackageImpl implements N4JSPackage {
 		initEOperation(getGetterDeclaration__GetDefinedAccessor(), theTypesPackage.getTGetter(), "getDefinedAccessor", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEClass(setterDeclarationEClass, SetterDeclaration.class, "SetterDeclaration", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getSetterDeclaration_DefinedSetter(), theTypesPackage.getTSetter(), null, "definedSetter", null, 0, 1, SetterDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getSetterDeclaration_DefinedSetter(), theTypesPackage.getTSetter(), null, "definedSetter", null, 0, 1, SetterDeclaration.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getSetterDeclaration_Fpar(), this.getFormalParameter(), null, "fpar", null, 0, 1, SetterDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEOperation(getSetterDeclaration__GetDefinedAccessor(), theTypesPackage.getTSetter(), "getDefinedAccessor", 0, 1, !IS_UNIQUE, IS_ORDERED);
@@ -7544,7 +7544,7 @@ public class N4JSPackageImpl extends EPackageImpl implements N4JSPackage {
 		initEOperation(getN4MemberAnnotationList__GetName(), theEcorePackage.getEString(), "getName", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEClass(n4FieldDeclarationEClass, N4FieldDeclaration.class, "N4FieldDeclaration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getN4FieldDeclaration_DefinedField(), theTypesPackage.getTField(), null, "definedField", null, 0, 1, N4FieldDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getN4FieldDeclaration_DefinedField(), theTypesPackage.getTField(), null, "definedField", null, 0, 1, N4FieldDeclaration.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getN4FieldDeclaration_Expression(), this.getExpression(), null, "expression", null, 0, 1, N4FieldDeclaration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEOperation(getN4FieldDeclaration__GetDefinedTypeElement(), theTypesPackage.getTMember(), "getDefinedTypeElement", 0, 1, !IS_UNIQUE, IS_ORDERED);

--- a/plugins/eu.numberfour.n4js.model/model/N4JS.xcore
+++ b/plugins/eu.numberfour.n4js.model/model/N4JS.xcore
@@ -899,7 +899,7 @@ class IdentifierRef extends PrimaryExpression, StrictModeRelevant {
 }
 
 abstract class StrictModeRelevant {
-	derived boolean strictMode
+	derived transient boolean strictMode
 }
 
 class SuperLiteral extends PrimaryExpression {
@@ -965,7 +965,7 @@ abstract class PropertyNameOwner extends NamedElement {
 	/*
 	 * This is set by the IAstFactory while parsing a property assignment.
 	 */
-	PropertyNameKind kind
+	transient PropertyNameKind kind
 	String name
 	op TStructMember getDefinedMember()
 	/**
@@ -1030,7 +1030,7 @@ enum PropertyNameKind {
 }
 
 class PropertyNameValuePair extends AnnotablePropertyAssignment, TypedElement, TypableElement {
-	refers TStructField definedField
+	refers transient TStructField definedField
 	/*
 	 * The (initial) value of the property.
 	 */
@@ -1084,7 +1084,7 @@ abstract class GetterDeclaration extends FieldAccessor, TypedElement {
  * Base class for setters, of either object literals (PropertySetterDeclaration) or classes (N4SetterDeclaration).
  */
 abstract class SetterDeclaration extends FieldAccessor {
-	refers TSetter definedSetter
+	refers transient TSetter definedSetter
 	contains FormalParameter fpar
 	op TSetter getDefinedAccessor() {
 		return definedSetter;
@@ -1843,7 +1843,7 @@ class N4MemberAnnotationList extends AbstractAnnotationList, N4MemberDeclaration
 }
 
 class N4FieldDeclaration extends AnnotableN4MemberDeclaration, TypedElement, ThisArgProvider, PropertyNameOwner {
-	refers TField definedField
+	refers transient TField definedField
 	/*
 	 * Initializer expression.
 	 */

--- a/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/typeRefs/StructuralTypeRef.java
+++ b/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/typeRefs/StructuralTypeRef.java
@@ -95,7 +95,7 @@ public interface StructuralTypeRef extends EObject {
 	 * @return the value of the '<em>Structural Type</em>' reference.
 	 * @see #setStructuralType(TStructuralType)
 	 * @see eu.numberfour.n4js.ts.typeRefs.TypeRefsPackage#getStructuralTypeRef_StructuralType()
-	 * @model
+	 * @model transient="true"
 	 * @generated
 	 */
 	TStructuralType getStructuralType();

--- a/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/typeRefs/impl/TypeRefsPackageImpl.java
+++ b/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/typeRefs/impl/TypeRefsPackageImpl.java
@@ -2062,7 +2062,7 @@ public class TypeRefsPackageImpl extends EPackageImpl implements TypeRefsPackage
 
 		initEClass(structuralTypeRefEClass, StructuralTypeRef.class, "StructuralTypeRef", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getStructuralTypeRef_AstStructuralMembers(), theTypesPackage.getTStructMember(), null, "astStructuralMembers", null, 0, -1, StructuralTypeRef.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getStructuralTypeRef_StructuralType(), theTypesPackage.getTStructuralType(), null, "structuralType", null, 0, 1, StructuralTypeRef.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getStructuralTypeRef_StructuralType(), theTypesPackage.getTStructuralType(), null, "structuralType", null, 0, 1, StructuralTypeRef.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getStructuralTypeRef_GenStructuralMembers(), theTypesPackage.getTStructMember(), null, "genStructuralMembers", null, 0, -1, StructuralTypeRef.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getStructuralTypeRef_PostponedSubstitutions(), this.getTypeVariableMapping(), null, "postponedSubstitutions", null, 0, -1, StructuralTypeRef.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 

--- a/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/types/TStructMember.java
+++ b/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/types/TStructMember.java
@@ -48,7 +48,7 @@ public interface TStructMember extends TMember {
 	 * @return the value of the '<em>Defined Member</em>' reference.
 	 * @see #setDefinedMember(TStructMember)
 	 * @see eu.numberfour.n4js.ts.types.TypesPackage#getTStructMember_DefinedMember()
-	 * @model
+	 * @model transient="true"
 	 * @generated
 	 */
 	TStructMember getDefinedMember();

--- a/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/types/impl/TypesPackageImpl.java
+++ b/plugins/eu.numberfour.n4js.ts.model/emf-gen/eu/numberfour/n4js/ts/types/impl/TypesPackageImpl.java
@@ -3451,7 +3451,7 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		initEOperation(getTMemberWithAccessModifier__GetMemberAccessModifier(), this.getMemberAccessModifier(), "getMemberAccessModifier", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEClass(tStructMemberEClass, TStructMember.class, "TStructMember", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getTStructMember_DefinedMember(), this.getTStructMember(), null, "definedMember", null, 0, 1, TStructMember.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTStructMember_DefinedMember(), this.getTStructMember(), null, "definedMember", null, 0, 1, TStructMember.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEOperation(getTStructMember__GetDefaultMemberAccessModifier(), this.getMemberAccessModifier(), "getDefaultMemberAccessModifier", 0, 1, !IS_UNIQUE, IS_ORDERED);
 

--- a/plugins/eu.numberfour.n4js.ts.model/model/TypeRefs.xcore
+++ b/plugins/eu.numberfour.n4js.ts.model/model/TypeRefs.xcore
@@ -578,7 +578,7 @@ abstract class StructuralTypeRef {
 	 * contains the structural members. In this case, properties 'astStructuralType' and 'genStructuralType'
 	 * are empty.
 	 */
-	refers TStructuralType structuralType
+	refers transient TStructuralType structuralType
 	/*
 	 * If a StructuralTypeRef with additional structural members is to be generated programmatically <em>without
 	 * having a TModule</em> at hand, then the structural members can be added to this property. If a TModule is

--- a/plugins/eu.numberfour.n4js.ts.model/model/Types.xcore
+++ b/plugins/eu.numberfour.n4js.ts.model/model/Types.xcore
@@ -1082,7 +1082,7 @@ abstract class TStructMember extends TMember {
 	 * the AST model. This property is set by the types builder and should never be changed by code
 	 * outside the types builder.
 	 */
-	refers TStructMember definedMember
+	refers transient TStructMember definedMember
 
 	/**
 	 * The default access modifier for struct members is public. This cannot be changed.


### PR DESCRIPTION
Marking an EStructuralFeature as 'transient' instructs Xtext's
serializer to ignore values from this feature during serialization.

If marking the features as transient in Xcore is not a possibility, 
an alternative solution is to implement 
org.eclipse.xtext.serializer.sequencer.ITransientValueService

Signed-off-by: Moritz Eysholdt moritz.eysholdt@typefox.io
